### PR TITLE
feat(notifications): sync badge, fix mark-all-read, and improve UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,6 +48,7 @@ import { AddSpeciality } from "./features/speciality/components";
 
 // notification
 import { NotificationProvider } from './contexts/NotificationContext';
+import NotificationsPage from './features/notifications/pages/NotificationsPage';
 
 
 function App() {
@@ -170,6 +171,13 @@ function App() {
         <Route path="/all-appointments" element={
           <ProtectedRoute>
             <AllAppointmentsPage />
+          </ProtectedRoute>
+        } />
+
+        {/* notifications */}
+        <Route path="/notifications" element={
+          <ProtectedRoute>
+            <NotificationsPage />
           </ProtectedRoute>
         } />
 

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -14,7 +14,7 @@ export default function Navbar() {
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState(null);
   const { user, isAuthenticated, logout } = useAuth();
-  const { notifications, unreadCount, markNotificationAsRead, markAllNotificationsAsRead, refreshNotifications, loadMoreNotifications, loading } = useNotifications();
+  const { notifications, unreadCount, markNotificationAsRead, markAllNotificationsAsRead, refreshNotifications, loading } = useNotifications();
   const [notificationAnchorEl, setNotificationAnchorEl] = useState(null);
 
   const handleMenuOpen = (event) => setAnchorEl(event.currentTarget);
@@ -98,14 +98,8 @@ export default function Navbar() {
               style: {
                 maxHeight: 400,
                 width: '350px',
-                overflowY: 'auto', // Enable scrolling
+                overflowY: 'auto',
               },
-              onScroll: (e) => {
-                const { scrollTop, clientHeight, scrollHeight } = e.target;
-                if (scrollHeight - scrollTop <= clientHeight + 10) { // Near bottom
-                  loadMoreNotifications();
-                }
-              }
             }}
           >
             <Box sx={{ p: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '1px solid #eee' }}>
@@ -164,6 +158,26 @@ export default function Navbar() {
                 <Typography variant="caption">Loading...</Typography>
               </Box>
             )}
+            {/* Show All button */}
+            <Box sx={{ p: 1, borderTop: '1px solid #eee' }}>
+              <MenuItem
+                id="show-all-notifications-btn"
+                onClick={() => {
+                  handleNotificationClose();
+                  navigate('/notifications');
+                }}
+                sx={{
+                  justifyContent: 'center',
+                  color: 'primary.main',
+                  fontWeight: 600,
+                  fontSize: '0.85rem',
+                  borderRadius: 1,
+                  '&:hover': { backgroundColor: 'rgba(25,118,210,0.08)' },
+                }}
+              >
+                Show All Notifications
+              </MenuItem>
+            </Box>
           </Menu>
 
           <IconButton size="large" edge="end" color="inherit" onClick={handleMenuOpen}>

--- a/src/features/notifications/components/NotificationCard.js
+++ b/src/features/notifications/components/NotificationCard.js
@@ -1,0 +1,177 @@
+import React from "react";
+import {
+  Avatar,
+  Box,
+  Chip,
+  Fade,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from "@mui/material";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import CancelIcon from "@mui/icons-material/Cancel";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import MedicalServicesIcon from "@mui/icons-material/MedicalServices";
+import InfoIcon from "@mui/icons-material/Info";
+
+// ─── Type config ──────────────────────────────────────────────────────────────
+
+const typeConfig = {
+  AppointmentCancelled: {
+    icon: <CancelIcon fontSize="small" />,
+    color: "#ef4444",
+    bg: "rgba(239,68,68,0.12)",
+    label: "Cancelled",
+  },
+  AppointmentBooked: {
+    icon: <CalendarMonthIcon fontSize="small" />,
+    color: "#22c55e",
+    bg: "rgba(34,197,94,0.12)",
+    label: "Booked",
+  },
+  PatientCheckedIn: {
+    icon: <PersonAddIcon fontSize="small" />,
+    color: "#3b82f6",
+    bg: "rgba(59,130,246,0.12)",
+    label: "Checked In",
+  },
+  DoctorAdded: {
+    icon: <MedicalServicesIcon fontSize="small" />,
+    color: "#a855f7",
+    bg: "rgba(168,85,247,0.12)",
+    label: "Doctor Added",
+  },
+  default: {
+    icon: <InfoIcon fontSize="small" />,
+    color: "#64748b",
+    bg: "rgba(100,116,139,0.12)",
+    label: "Info",
+  },
+};
+
+const getTypeConfig = (type) => typeConfig[type] ?? typeConfig.default;
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+const formatTime = (dateStr) => {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function NotificationCard({ notification, onMarkRead }) {
+  const cfg = getTypeConfig(notification.type);
+  const isUnread = !notification.isRead;
+
+  return (
+    <Fade in>
+      <ListItem
+        id={`notification-${notification.id}`}
+        alignItems="flex-start"
+        sx={{
+          borderRadius: 2,
+          mb: 1,
+          px: 2,
+          py: 1.5,
+          background: isUnread
+            ? "linear-gradient(135deg, rgba(25,118,210,0.07) 0%, rgba(25,118,210,0.03) 100%)"
+            : "#fafbfc",
+          border: "1px solid",
+          borderColor: isUnread ? "rgba(25,118,210,0.25)" : "#e2e8f0",
+          transition: "all 0.2s ease",
+          cursor: isUnread ? "pointer" : "default",
+          "&:hover": {
+            borderColor: isUnread ? "rgba(25,118,210,0.5)" : "#cbd5e1",
+            transform: "translateY(-1px)",
+            boxShadow: "0 4px 16px rgba(0,0,0,0.07)",
+          },
+        }}
+        onClick={() => isUnread && onMarkRead(notification.id)}
+      >
+        {/* Avatar */}
+        <ListItemAvatar sx={{ minWidth: 48, mt: 0.5 }}>
+          <Avatar
+            sx={{
+              width: 36,
+              height: 36,
+              bgcolor: cfg.bg,
+              color: cfg.color,
+              border: `2px solid ${cfg.color}30`,
+            }}
+          >
+            {cfg.icon}
+          </Avatar>
+        </ListItemAvatar>
+
+        {/* Content */}
+        <ListItemText
+          disableTypography
+          primary={
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap", mb: 0.5 }}>
+              <Typography
+                variant="subtitle2"
+                fontWeight={isUnread ? 700 : 500}
+                sx={{ color: isUnread ? "text.primary" : "text.secondary" }}
+              >
+                {notification.title}
+              </Typography>
+              <Chip
+                label={cfg.label}
+                size="small"
+                sx={{
+                  height: 18,
+                  fontSize: "0.65rem",
+                  fontWeight: 600,
+                  bgcolor: cfg.bg,
+                  color: cfg.color,
+                  border: "none",
+                }}
+              />
+              {isUnread && (
+                <Box
+                  sx={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: "50%",
+                    bgcolor: "primary.main",
+                    flexShrink: 0,
+                    ml: "auto",
+                    boxShadow: "0 0 6px rgba(25,118,210,0.7)",
+                  }}
+                />
+              )}
+            </Box>
+          }
+          secondary={
+            <Box>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ lineHeight: 1.5, mb: 0.75 }}
+              >
+                {notification.message}
+              </Typography>
+              <Typography variant="caption" color="text.disabled">
+                {formatDate(notification.createdAt)} · {formatTime(notification.createdAt)}
+              </Typography>
+            </Box>
+          }
+        />
+      </ListItem>
+    </Fade>
+  );
+}

--- a/src/features/notifications/components/NotificationsPagination.js
+++ b/src/features/notifications/components/NotificationsPagination.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { Box, Pagination } from "@mui/material";
+
+export default function NotificationsPagination({ page, totalPages, onChange }) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+      <Pagination
+        id="notifications-pagination"
+        count={totalPages}
+        page={page}
+        onChange={onChange}
+        color="primary"
+        shape="rounded"
+        showFirstButton
+        showLastButton
+        sx={{
+          "& .MuiPaginationItem-root": {
+            color: "#000000",
+            borderColor: "#000000",
+          },
+          "& .MuiPaginationItem-root.Mui-selected": {
+            background: "linear-gradient(135deg, #1976d2, #42a5f5)",
+            color: "white",
+            fontWeight: 700,
+          },
+          "& .MuiPaginationItem-root:hover": {
+            backgroundColor: "rgba(25,118,210,0.15)",
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/features/notifications/pages/NotificationsPage.js
+++ b/src/features/notifications/pages/NotificationsPage.js
@@ -1,0 +1,286 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Divider,
+  IconButton,
+  List,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import NotificationsIcon from "@mui/icons-material/Notifications";
+import DoneAllIcon from "@mui/icons-material/DoneAll";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+import { getUserNotifications } from "../../../services/notificationService";
+import { useNotifications } from "../../../contexts/NotificationContext";
+import NotificationCard from "../components/NotificationCard";
+import NotificationsPagination from "../components/NotificationsPagination";
+
+// ─── Normalize API shape ──────────────────────────────────────────────────────
+
+const normalize = (n) => ({
+  id: n.id ?? n.Id,
+  title: n.title ?? n.Title,
+  message: n.message ?? n.Message,
+  isRead: n.isRead !== undefined ? n.isRead : n.IsRead,
+  createdAt: n.createdAt ?? n.CreatedAt,
+  type: n.type ?? n.Type,
+});
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+export default function NotificationsPage() {
+  const {
+    markNotificationAsRead,
+    markAllNotificationsAsRead,
+    unreadCount: contextUnreadCount,
+  } = useNotifications();
+
+  const [notifications, setNotifications] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [markingAll, setMarkingAll] = useState(false);
+
+  // local unread derived from page state; context drives the navbar badge
+  const unreadCount = notifications.filter((n) => !n.isRead).length;
+
+  // ─── Fetch ──────────────────────────────────────────────────────────────────
+
+  const fetchPage = useCallback(async (pageNum) => {
+    setLoading(true);
+    try {
+      const response = await getUserNotifications(pageNum);
+      // API returns PascalCase for Data array, camelCase for meta fields
+      const raw = response?.Data ?? response?.data ?? [];
+      const count = response?.totalCount ?? response?.TotalCount ?? raw.length;
+      const pageSize = response?.pageSize ?? response?.PageSize ?? 6;
+      const pages = Math.ceil(count / pageSize) || 1;
+
+      setNotifications(raw.map(normalize));
+      setTotalCount(count);
+      setTotalPages(pages);
+    } catch (err) {
+      console.error("Failed to fetch notifications:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPage(page);
+  }, [page, fetchPage]);
+
+  // ─── Actions ─────────────────────────────────────────────────────────────────
+
+  const handleMarkRead = async (id) => {
+    try {
+      // update context (→ navbar badge) AND local page state
+      await markNotificationAsRead(id);
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, isRead: true } : n))
+      );
+    } catch (err) {
+      console.error("Failed to mark as read:", err);
+    }
+  };
+
+  const handleMarkAllRead = async () => {
+    setMarkingAll(true);
+    try {
+      // update context (→ navbar badge) AND local page state
+      await markAllNotificationsAsRead();
+      setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+    } catch (err) {
+      console.error("Failed to mark all as read:", err);
+    } finally {
+      setMarkingAll(false);
+    }
+  };
+
+  const handlePageChange = (_, value) => {
+    setPage(value);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  // ─── Render ───────────────────────────────────────────────────────────────────
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        background: "linear-gradient(160deg, #f0f4f8 0%, #e8eef5 50%, #f0f4f8 100%)",
+        pt: 4,
+        pb: 8,
+      }}
+    >
+      <Container maxWidth="md">
+        {/* ── Header ─────────────────────────────────────────────────────── */}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            flexWrap: "wrap",
+            gap: 2,
+            mb: 4,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+            <Badge badgeContent={unreadCount || null} color="error" overlap="circular">
+              <Avatar
+                sx={{
+                  width: 44,
+                  height: 44,
+                  background: "linear-gradient(135deg, #1976d2, #42a5f5)",
+                  boxShadow: "0 4px 14px rgba(25,118,210,0.3)",
+                }}
+              >
+                <NotificationsIcon />
+              </Avatar>
+            </Badge>
+            <Box>
+              <Typography variant="h5" fontWeight={700} color="#1e293b">
+                Notifications
+              </Typography>
+              <Typography variant="caption" sx={{ color: "#64748b" }}>
+                {totalCount > 0
+                  ? `${totalCount} total · ${unreadCount} unread`
+                  : "No notifications yet"}
+              </Typography>
+            </Box>
+          </Box>
+
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Tooltip title="Refresh">
+              <IconButton
+                id="refresh-notifications-btn"
+                onClick={() => fetchPage(page)}
+                size="small"
+                sx={{ color: "#64748b", "&:hover": { color: "#1976d2" } }}
+              >
+                <RefreshIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+
+            {unreadCount > 0 && (
+              <Button
+                id="mark-all-read-btn"
+                size="small"
+                variant="outlined"
+                startIcon={
+                  markingAll ? (
+                    <CircularProgress size={14} color="inherit" />
+                  ) : (
+                    <DoneAllIcon />
+                  )
+                }
+                disabled={markingAll}
+                onClick={handleMarkAllRead}
+                sx={{
+                  borderColor: "#1976d2",
+                  color: "#1976d2",
+                  textTransform: "none",
+                  borderRadius: 2,
+                  "&:hover": {
+                    borderColor: "#1565c0",
+                    background: "rgba(25,118,210,0.06)",
+                  },
+                }}
+              >
+                Mark all as read
+              </Button>
+            )}
+          </Stack>
+        </Box>
+
+        {/* ── Notification list card ──────────────────────────────────────── */}
+        <Box
+          sx={{
+            background: "#ffffff",
+            border: "1px solid #e2e8f0",
+            borderRadius: 3,
+            overflow: "hidden",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
+          }}
+        >
+          {loading ? (
+            <Box
+              sx={{ display: "flex", justifyContent: "center", alignItems: "center", py: 10 }}
+            >
+              <CircularProgress />
+            </Box>
+          ) : notifications.length === 0 ? (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                py: 10,
+                gap: 2,
+                color: "text.secondary",
+              }}
+            >
+              <NotificationsIcon sx={{ fontSize: 56, opacity: 0.3 }} />
+              <Typography variant="body1">You're all caught up!</Typography>
+              <Typography variant="caption">No notifications on this page.</Typography>
+            </Box>
+          ) : (
+            <>
+              {/* Page info bar */}
+              <Box
+                sx={{
+                  px: 2,
+                  pt: 2,
+                  pb: 1,
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{ color: "#94a3b8", textTransform: "uppercase", letterSpacing: 1 }}
+                >
+                  Page {page} of {totalPages}
+                </Typography>
+                {unreadCount > 0 && (
+                  <Chip
+                    label={`${unreadCount} unread`}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                    sx={{ height: 20, fontSize: "0.65rem" }}
+                  />
+                )}
+              </Box>
+
+              <Divider sx={{ borderColor: "#f1f5f9", mx: 2 }} />
+
+              <List sx={{ px: 1, pt: 1 }}>
+                {notifications.map((n) => (
+                  <NotificationCard key={n.id} notification={n} onMarkRead={handleMarkRead} />
+                ))}
+              </List>
+            </>
+          )}
+        </Box>
+
+        {/* ── Pagination ─────────────────────────────────────────────────── */}
+        <NotificationsPagination
+          page={page}
+          totalPages={totalPages}
+          onChange={handlePageChange}
+        />
+      </Container>
+    </Box>
+  );
+}

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,8 +1,8 @@
 import api from "../api/axios";
 
-export const getUserNotifications = async (pageNumber = 1, pageSize = 6) => {
+export const getUserNotifications = async (pageNumber) => {
     try {
-        const response = await api.get(`/Notification/User?pageNumber=${pageNumber}&pageSize=${pageSize}`);
+        const response = await api.get(`/Notification/User?pageNumber=${pageNumber}`);
         return response.data;
     } catch (error) {
         console.error("Error fetching user notifications:", error);


### PR DESCRIPTION
- Update NotificationsPage & NotificationCard colors to light theme (soft blue-gray background, white card surface, blue accents)
- Fix "Mark all as read" in NotificationsPage to use context actions (markAllNotificationsAsRead / markNotificationAsRead) so the navbar badge count updates immediately
- Remove infinite-scroll onScroll handler from navbar notification dropdown — no more extra API calls on scroll; first page only shown